### PR TITLE
Use venv python to fix sudo breaking venv

### DIFF
--- a/bin/docker-containerizer
+++ b/bin/docker-containerizer
@@ -25,4 +25,4 @@ fi
 export PYTHONPATH="`pwd`:$PYTHONPATH"
 
 # We run as sudo here because to modify cgroup properties, we must be root.
-sudo -E LD_LIBRARY_PATH="$LD_LIBRARY_PATH" python -m containerizer.__main__ $@
+sudo -E LD_LIBRARY_PATH="$LD_LIBRARY_PATH" bin/env/bin/python -m containerizer.__main__ $@


### PR DESCRIPTION
Sudo will break some of the venv configuration, resulting in the containerizer not being able to locate the click module.

Fix by using the python from the virtualenv where click is installed.
