### PR TITLE
Replace any $MESOS_DIRECTORY variables

### DIFF
--- a/containerizer/commands/launch.py
+++ b/containerizer/commands/launch.py
@@ -142,6 +142,9 @@ def launch():
             for option in launch.task_info.command.container.options:
                 extra_args.extend(option.split(" "))
 
+        # Replace any environment variables in the custom args
+        extra_args = map(lambda s: s.replace('$MESOS_DIRECTORY', launch.directory), extra_args)
+
         if not image:
             image = os.environ["MESOS_DEFAULT_CONTAINER_IMAGE"]
         if not image:


### PR DESCRIPTION
For some situations, it can be desirable to mount a directory INSIDE the sandbox, as a volume. Currently there is no mechanism to do this, so I am introducing a new variable that can be used in the docker extra args.
