### PR TITLE
Remove the libmesos.so mount

### DIFF
--- a/containerizer/commands/launch.py
+++ b/containerizer/commands/launch.py
@@ -83,7 +83,6 @@ def launch():
 
         # Link the mesos native library
         native_library = os.environ['MESOS_NATIVE_LIBRARY']
-        arguments.extend(["-v", "%s:/usr/local/lib/%s" % (native_library, os.path.basename(native_library))])
 
         # Set the resource configuration
         cpu_shares = 0


### PR DESCRIPTION
This causes way too many issues with dynamically linked dependencies inside of containers.
