### PR TITLE
Adjust cgroup limits to mirror mesos docker behaviour

### DIFF
--- a/containerizer/commands/launch.py
+++ b/containerizer/commands/launch.py
@@ -143,7 +143,7 @@ def build_docker_args(launch):
                         ports.add(port)
 
     if cpu_shares > 0.0:
-        arguments.extend(["-c", str(int(cpu_shares * 256))])
+        arguments.extend(["-c", str(int(cpu_shares * 1024))])
     if max_memory > 0:
         arguments.extend(["-m", "%dm" % max_memory])
     if len(ports) > 0:

--- a/containerizer/commands/update.py
+++ b/containerizer/commands/update.py
@@ -61,7 +61,7 @@ def update_container(container_id, resources):
         # If we reduce the hard limit and too much memory is in use, this
         # can invoke an OOM.
         current_mem = int(read_metric(lxc_container_id, "memory.limit_in_bytes"))
-        if current_mem > max_mem:
+        if current_mem < max_mem:
             write_metric(lxc_container_id, "memory.limit_in_bytes", max_mem)
         else:
             logger.info("Skipping hard memory limit, would invoke OOM")

--- a/containerizer/commands/update.py
+++ b/containerizer/commands/update.py
@@ -49,7 +49,7 @@ def update_container(container_id, resources):
         if resource.name == "mem":
             max_mem = int(resource.scalar.value) * 1024 * 1024
         if resource.name == "cpus":
-            max_cpus = int(resource.scalar.value) * 256
+            max_cpus = int(resource.scalar.value) * 1024
         if resource.name == "ports":
             logger.error("Unable to process an update to port configuration!")
 
@@ -67,7 +67,7 @@ def update_container(container_id, resources):
             logger.info("Skipping hard memory limit, would invoke OOM")
 
     if max_cpus:
-        shares = max_cpus * 256
+        shares = max_cpus * 1024
         write_metric(lxc_container_id, "cpu.shares", shares)
 
     logger.info("Finished processing container update")

--- a/tests/commands/test_launch.py
+++ b/tests/commands/test_launch.py
@@ -67,7 +67,7 @@ class LaunchContainerTestCase(TestCase):
             "--name", "container-foo-bar",
             "--net", "host",
             "-u", "test",
-            "-c", "256",
+            "-c", "1024",
             "-m", "1024m",
             "-p", ":4400",
             "-p", ":4401",


### PR DESCRIPTION
These changes bring the docker+cgroups implementation in line with the [built in mesos/docker containerizer](https://github.com/apache/mesos/blob/master/src/slave/containerizer/docker.cpp#L907).

- Use 1024 CPU shares instead of 256
- Only change the hard memory limit if it's greater than the current limit