### PR TITLE
Fix for double counting CPU shares

### DIFF
--- a/containerizer/commands/update.py
+++ b/containerizer/commands/update.py
@@ -49,7 +49,7 @@ def update_container(container_id, resources):
         if resource.name == "mem":
             max_mem = int(resource.scalar.value) * 1024 * 1024
         if resource.name == "cpus":
-            max_cpus = int(resource.scalar.value) * 1024
+            max_cpus = int(resource.scalar.value)
         if resource.name == "ports":
             logger.error("Unable to process an update to port configuration!")
 


### PR DESCRIPTION
Pretty horrific bug related to over allocating CPU shares when asked to update the resources for a running container by Mesos. We're *1024 twice currently which basically over-allocates CPU shares by several orders of magnitude.

:expressionless: 
